### PR TITLE
Cooldown redundancy fix #2

### DIFF
--- a/CodeAZ-BOT/docs/ARCHITECTURE.md
+++ b/CodeAZ-BOT/docs/ARCHITECTURE.md
@@ -1,0 +1,9 @@
+# CodeAZ-BOT
+## Written by CodeAZ Community
+
+### Features:
+- Limiting commands to one channel
+- XP system
+- Welcome messages and roles
+- Meme command via meme-api
+- Reaction Roles

--- a/CodeAZ-BOT/src/bot.py
+++ b/CodeAZ-BOT/src/bot.py
@@ -178,12 +178,18 @@ if config["features"]["xp"].get("enabled"):
         @commands.cooldown(1, xp_send_cooldown, commands.BucketType.user)
         async def xp_send(ctx, amount: int, *members: discord.Member):
             if xp_send_role not in [r.id for r in ctx.author.roles]:
+                await ctx.reply(f"Bu əmr üçün sizdə yetərli rol yoxdur!")
+                xp_send.reset_cooldown(ctx)
                 return
 
             if amount <= 0:
+                await ctx.reply(f"Miqdar 0-dan çox olmalıdır.")
+                xp_send.reset_cooldown(ctx)
                 return
 
             if amount > xp_send_maximum:
+                await ctx.reply(f"Miqdar {xp_send_maximum}-dan az olmalıdır.")
+                xp_send.reset_cooldown(ctx)
                 return
 
             with open(XP_JSON, "r", encoding="utf-8") as f:

--- a/CodeAZ-BOT/src/bot.py
+++ b/CodeAZ-BOT/src/bot.py
@@ -6,8 +6,9 @@ import json
 import math
 import aiohttp
 from log import logger
-
+#======================
 # -- Configuration -- #
+#======================
 
 with open(CONFIG_JSON, "r", encoding="utf-8") as file:
     config = json.load(file)
@@ -60,18 +61,22 @@ if config["features"]["reaction"]["role"].get("enabled"):
 
 intents = discord.Intents.all()
 bot = commands.Bot(command_prefix=command_prefix, intents=intents, help_command=None)
-
+#==================
 # -- Functions -- #
+#==================
 
+#================
 # -- Channel -- #
+#================
 
 if config["features"]["channel"].get("enabled"):
     @bot.check
     async def globally_check_channel(ctx):
         logger.debug(f"Checking if command is allowed in channel {ctx.channel.id}")
         return ctx.channel.id == channel
-
+#================
 # -- Welcome -- #
+#================
 
 if config["features"]["welcome"].get("enabled"):
     @bot.event
@@ -86,7 +91,9 @@ if config["features"]["welcome"].get("enabled"):
                 await member.add_roles(role)
                 logger.info(f"Assigned role '{role.name}' to {member.name}")
 
+#======================
 # -- Reaction Role -- #
+#======================
 
 if config["features"]["reaction"].get("role")["enabled"]:
     @bot.event
@@ -119,7 +126,9 @@ if config["features"]["reaction"].get("role")["enabled"]:
                 await member.remove_roles(role)
                 logger.info(f"Removed role '{role.name}' from {member.name} for reaction {payload.emoji}")
 
+#====================
 # -- XP System -- #
+#====================
 
 if config["features"]["xp"].get("enabled"):
     @bot.event
@@ -302,8 +311,10 @@ if config["features"]["xp"].get("enabled"):
             if isinstance(error, commands.CommandOnCooldown):
                 seconds_left = math.ceil(error.retry_after)
                 await ctx.reply(f"Bu əmri təkrar etmək üçün {seconds_left} saniyə gözləməlisiniz!")
-
+                
+#======================
 # -- Meme -- #
+#======================
 
 if config["features"]["meme"].get("enabled"):
     @bot.command(name=meme_command)

--- a/CodeAZ-BOT/src/bot.py
+++ b/CodeAZ-BOT/src/bot.py
@@ -1,22 +1,3 @@
-
-"""
-~Docboard for CodeAZ-BOT/src/bot.py
-
-# A simple bot designed 
-# for the CodeAZ community server
-# with the discord.py API
-# by the CodeAZ community
-
-### Current features:
-- xp system
-- a leaderboard for the xp system
-- simple xp transfer commands, such as xp-give and xp-send
-- a basic "gambling" command with a 10% winrate
-- a meme command using the meme-api.com API
-- modifiable through the config file
-
-"""
-
 from path import CONFIG_JSON, XP_JSON
 from discord.ext import commands
 import discord
@@ -26,9 +7,7 @@ import math
 import aiohttp
 from log import logger
 
-#======================
 # -- Configuration -- #
-#======================
 
 with open(CONFIG_JSON, "r", encoding="utf-8") as file:
     config = json.load(file)
@@ -81,22 +60,18 @@ if config["features"]["reaction"]["role"].get("enabled"):
 
 intents = discord.Intents.all()
 bot = commands.Bot(command_prefix=command_prefix, intents=intents, help_command=None)
-#==================
-# -- Functions -- #
-#==================
 
-#================
+# -- Functions -- #
+
 # -- Channel -- #
-#================
 
 if config["features"]["channel"].get("enabled"):
     @bot.check
     async def globally_check_channel(ctx):
         logger.debug(f"Checking if command is allowed in channel {ctx.channel.id}")
         return ctx.channel.id == channel
-#================
+
 # -- Welcome -- #
-#================
 
 if config["features"]["welcome"].get("enabled"):
     @bot.event
@@ -111,9 +86,7 @@ if config["features"]["welcome"].get("enabled"):
                 await member.add_roles(role)
                 logger.info(f"Assigned role '{role.name}' to {member.name}")
 
-#======================
 # -- Reaction Role -- #
-#======================
 
 if config["features"]["reaction"].get("role")["enabled"]:
     @bot.event
@@ -146,9 +119,7 @@ if config["features"]["reaction"].get("role")["enabled"]:
                 await member.remove_roles(role)
                 logger.info(f"Removed role '{role.name}' from {member.name} for reaction {payload.emoji}")
 
-#====================
 # -- XP System -- #
-#====================
 
 if config["features"]["xp"].get("enabled"):
     @bot.event
@@ -266,7 +237,7 @@ if config["features"]["xp"].get("enabled"):
             receiver = str(member.id)
 
             if xp.get(giver, 0) < amount:
-                await ctx.reply(f"Sizdə yetər qədər XP yoxdur.")
+                await ctx.reply(f"Sizdə kifayət qədər XP yoxdur.")
                 xp_give.reset_cooldown(ctx)
                 return
 
@@ -296,7 +267,7 @@ if config["features"]["xp"].get("enabled"):
                 return
             
             if amount <= 0:
-                await ctx.reply(f"Miqdar 0-dan çox olmalıdır.")
+                await ctx.reply(f"Miqdar 0-dan çox olmalıdır")
                 xp_bet.reset_cooldown(ctx)
                 return
 
@@ -311,7 +282,7 @@ if config["features"]["xp"].get("enabled"):
             bettor = str(ctx.author.id)
 
             if xp.get(bettor, 0) < amount:
-                await ctx.reply(f"Sizdə yetər qədər XP yoxdur.")
+                await ctx.reply(f"Sizdə kifayət qədər XP yoxdur.")
                 xp_bet.reset_cooldown(ctx)
                 return
             
@@ -340,9 +311,7 @@ if config["features"]["xp"].get("enabled"):
                 seconds_left = math.ceil(error.retry_after)
                 await ctx.reply(f"Bu əmri təkrar etmək üçün {seconds_left} saniyə gözləməlisiniz!")
 
-#======================
 # -- Meme -- #
-#======================
 
 if config["features"]["meme"].get("enabled"):
     @bot.command(name=meme_command)
@@ -352,14 +321,12 @@ if config["features"]["meme"].get("enabled"):
         async with aiohttp.ClientSession() as session:
             async with session.get("https://meme-api.com/gimme") as resp:
                 if resp.status != 200:
-                    await ctx.reply(f"Xəta baş verdi! zəhmət olmasa bir necə dəqiqə sonra təkrar cəhd edin.")
+                    await ctx.reply(f"Zəhmət olmasa bir necə dəqiqə sonra təkrar cəhd edin.")
                     meme.reset_cooldown(ctx)
                     return
                 data = await resp.json()
                 if not meme_nsfw:
                     if data.get("nsfw") and not ctx.channel.is_nsfw():
-                        #await ctx.reply(f"Bu kanal sfw-dir.")
-                        meme.reset_cooldown(ctx)
                         return
 
         embed = discord.Embed(

--- a/CodeAZ-BOT/src/bot.py
+++ b/CodeAZ-BOT/src/bot.py
@@ -210,12 +210,18 @@ if config["features"]["xp"].get("enabled"):
         @commands.cooldown(1, xp_give_cooldown, commands.BucketType.user)
         async def xp_give(ctx, amount: int, member: discord.Member):
             if xp_give_role not in [r.id for r in ctx.author.roles]:
+                await ctx.reply(f"Bu əmr üçün sizdə yetərli rol yoxdur!")
+                xp_give.reset_cooldown(ctx)
                 return
             
             if amount <= 0:
+                await ctx.reply(f"Miqdar 0-dan çox olmalıdır.")
+                xp_give.reset_cooldown(ctx)
                 return
             
             if amount > xp_give_maximum:
+                await ctx.reply(f"Miqdar {xp_give_maximum}-dan az olmalıdır.")
+                xp_give.reset_cooldown(ctx)
                 return
             
             with open(XP_JSON, "r", encoding="utf-8") as file:
@@ -225,6 +231,8 @@ if config["features"]["xp"].get("enabled"):
             receiver = str(member.id)
 
             if xp.get(giver, 0) < amount:
+                await ctx.reply(f"Sizdə yetər qədər XP yoxdur.")
+                xp_give.reset_cooldown(ctx)
                 return
 
             xp[giver] -= amount

--- a/CodeAZ-BOT/src/bot.py
+++ b/CodeAZ-BOT/src/bot.py
@@ -1,3 +1,22 @@
+
+"""
+~Docboard for CodeAZ-BOT/src/bot.py
+
+# A simple bot designed 
+# for the CodeAZ community server
+# with the discord.py API
+# by the CodeAZ community
+
+### Current features:
+- xp system
+- a leaderboard for the xp system
+- simple xp transfer commands, such as xp-give and xp-send
+- a basic "gambling" command with a 10% winrate
+- a meme command using the meme-api.com API
+- modifiable through the config file
+
+"""
+
 from path import CONFIG_JSON, XP_JSON
 from discord.ext import commands
 import discord
@@ -6,6 +25,7 @@ import json
 import math
 import aiohttp
 from log import logger
+
 #======================
 # -- Configuration -- #
 #======================
@@ -311,7 +331,7 @@ if config["features"]["xp"].get("enabled"):
             if isinstance(error, commands.CommandOnCooldown):
                 seconds_left = math.ceil(error.retry_after)
                 await ctx.reply(f"Bu əmri təkrar etmək üçün {seconds_left} saniyə gözləməlisiniz!")
-                
+
 #======================
 # -- Meme -- #
 #======================

--- a/CodeAZ-BOT/src/bot.py
+++ b/CodeAZ-BOT/src/bot.py
@@ -352,10 +352,14 @@ if config["features"]["meme"].get("enabled"):
         async with aiohttp.ClientSession() as session:
             async with session.get("https://meme-api.com/gimme") as resp:
                 if resp.status != 200:
+                    await ctx.reply(f"Xəta baş verdi! zəhmət olmasa bir necə dəqiqə sonra təkrar cəhd edin.")
+                    meme.reset_cooldown(ctx)
                     return
                 data = await resp.json()
                 if not meme_nsfw:
                     if data.get("nsfw") and not ctx.channel.is_nsfw():
+                        #await ctx.reply(f"Bu kanal sfw-dir.")
+                        meme.reset_cooldown(ctx)
                         return
 
         embed = discord.Embed(

--- a/CodeAZ-BOT/src/bot.py
+++ b/CodeAZ-BOT/src/bot.py
@@ -291,12 +291,18 @@ if config["features"]["xp"].get("enabled"):
         @commands.cooldown(1, xp_bet_cooldown, commands.BucketType.user)
         async def xp_bet(ctx, amount: int):
             if xp_bet_role not in [r.id for r in ctx.author.roles]:
+                await ctx.reply(f"Bu əmr üçün sizdə yetərli rol yoxdur!")
+                xp_bet.reset_cooldown(ctx)
                 return
             
             if amount <= 0:
+                await ctx.reply(f"Miqdar 0-dan çox olmalıdır.")
+                xp_bet.reset_cooldown(ctx)
                 return
 
             if amount > xp_bet_maximum:
+                await ctx.reply(f"Miqdar {xp_bet_maximum}-dan az olmalıdır.")
+                xp_bet.reset_cooldown(ctx)
                 return
             
             with open(XP_JSON, "r", encoding="utf-8") as file:
@@ -305,6 +311,8 @@ if config["features"]["xp"].get("enabled"):
             bettor = str(ctx.author.id)
 
             if xp.get(bettor, 0) < amount:
+                await ctx.reply(f"Sizdə yetər qədər XP yoxdur.")
+                xp_bet.reset_cooldown(ctx)
                 return
             
             logger.info(f"{ctx.author.name} bet {amount}")


### PR DESCRIPTION
fixed a few issues where the command would give you cooldown even if it failed,
this was done by just reseting the cooldown after every failure and often warning the user about it.
Additionally, i added some pretty comments.

This is the second version of the pull request since the maintainer requested some minor changes.
i hope that this feature will be of use to somebody.
Thanks!
