### PR TITLE
Not allowing @ symbol in help commands

### DIFF
--- a/CodeAZ-BOT/src/bot.py
+++ b/CodeAZ-BOT/src/bot.py
@@ -99,6 +99,10 @@ if config["features"]["channel"].get("enabled"):
 if config["features"]["help"].get("enabled"):
     @bot.command(name=help_command)
     async def help(ctx, command: str = None):
+
+        if ("@" in command):
+            return            
+        
         default_explanation = help_explanation.get("default")
 
         if command is None:

--- a/CodeAZ-BOT/src/bot.py
+++ b/CodeAZ-BOT/src/bot.py
@@ -100,7 +100,7 @@ if config["features"]["help"].get("enabled"):
     @bot.command(name=help_command)
     async def help(ctx, command: str = None):
 
-        if ("@" in command):
+        if "@" in command:
             return            
         
         default_explanation = help_explanation.get("default")


### PR DESCRIPTION
People could use the @ symbol to tag ANYONE through the bot.